### PR TITLE
Pull HSE_VALUE from yotta config for feature parity with STM32F407 CMSIS

### DIFF
--- a/cmsis-core-stm32f405rg/stm32f405xx.h
+++ b/cmsis-core-stm32f405rg/stm32f405xx.h
@@ -56,6 +56,13 @@
  extern "C" {
 #endif /* __cplusplus */
 
+#undef  HSE_VALUE
+#define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
 
 /** @addtogroup Configuration_section_for_CMSIS
   * @{


### PR DESCRIPTION
openkosmosorg/KubOS#16